### PR TITLE
S3_setting

### DIFF
--- a/config/initializers/carierwave.rb
+++ b/config/initializers/carierwave.rb
@@ -7,8 +7,7 @@ CarrierWave.configure do |config|
   config.fog_provider = 'fog/aws'
   config.fog_credentials = {
     provider: 'AWS',
-    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
-    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+    aws_access_key_id: Rails.application.credentials.aws_access_key_id,
     region: 'ap-northeast-1'
   }
 


### PR DESCRIPTION
# what
画像アップロード先のS3の設定に誤りがあったので修正。

# why
Ruby5.2以降でsecret.ymlからcredential.yml.encに統合されたためん、carrierwave.rbの記述を変更